### PR TITLE
FH-4728 Bring travis over from CI/CD POC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+stages:
+  - name: Unit test
+    if: type IN (push)
+jobs:
+  include:
+    - stage: Unit test
+      language: node_js
+      node_js: 6
+      cache:
+        directories:
+        - node_modules
+      before_install:
+      - npm i -g yarn
+      install:
+      - yarn install
+      script:
+      - npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamic-dockerizer-agent",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Agent component of Dynamic Dockerizer",
   "main": "dist",
   "scripts": {


### PR DESCRIPTION
## Motivation
- Use travis for CICD

## Result
- .travis.yml is brought over from CICD POC: https://github.com/thailekha/rooms-checker-elm/blob/master/.travis.yml

## Jira
https://issues.jboss.org/browse/FH-4728