### PR TITLE
e2e tests kickoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,49 @@
-stages:
-  - name: Unit test
-    if: type IN (push)
+dd_common: &common
+  if: type IN (push)
+  sudo: required
+  dist: trusty
+  language: bash
+  cache:
+    directories:
+    - node_modules
+  before_install:
+  - sudo apt-get -y install git dpkg-repack tree build-essential apt-rdepends
+  - curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+  - sudo apt-get install -y nodejs
+  - sudo npm install -g yarn
+  before_script:
+  - npm run build
 jobs:
   include:
-    - stage: Unit test
-      language: node_js
-      node_js: 6
-      cache:
-        directories:
-        - node_modules
-      before_install:
-      - npm i -g yarn
+    # =======================
+    # Unit tests (start)
+    # =======================
+    -
+      <<: *common
       install:
       - yarn install
       script:
       - npm run test
+    # =======================
+    # Unit tests (end)
+    # =======================
+    # =======================
+    # E2E tests (start)
+    # =======================
+    -
+      <<: *common
+      install:
+      - sudo apt-get install nginx
+      - yarn install
+      script:
+      - sudo node ./node_modules/mocha/bin/mocha ./dist/tests/procezz.test.js --grep process --timeout 20000 --exit
+    -
+      <<: *common
+      install:
+      - sudo apt-get install nginx
+      - yarn install
+      script:
+      - sudo node ./node_modules/mocha/bin/mocha ./dist/tests/procezz.test.js --grep foo --timeout 20000 --exit
+    # =======================
+    # E2E tests (end)
+    # =======================

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "sourceType": "module"
     },
     "env": {
-      "node": true
+      "node": true,
+      "mocha": true
     },
     "rules": {
       "array-callback-return": "warn",
@@ -123,7 +124,10 @@
     "babel-core": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-stage-0": "^6.5.0",
+    "chai": "^4.1.2",
     "eslint": "^3.1.1",
-    "nodemon": "^1.9.2"
+    "mocha": "^5.0.0",
+    "nodemon": "^1.9.2",
+    "supertest": "^3.0.0"
   }
 }

--- a/src/tests/procezz.test.js
+++ b/src/tests/procezz.test.js
@@ -1,0 +1,41 @@
+import assert from 'assert';
+import request from 'supertest';
+import app from '../index';
+import chai from 'chai';
+import {shell} from '../lib/util';
+
+const expect = chai.expect;
+
+describe('process', function() {
+
+  before(function(done) {
+    shell(`service nginx start`, err => {
+      expect(err).to.be.null;
+      done();
+    });
+  });
+
+  it('should list TCP processes including nginx', done => {
+    request(app)
+      .get('/process')
+      .expect('Content-Type', /json/)
+      .end(function(err, res) {
+        expect(res.status).to.be.equal(200);
+        assert.equal(1, res.body.processes.filter(({program}) => program === 'nginx').length);
+        done();
+      });
+  });
+
+});
+
+describe('foo', function() {
+
+  before(function(done) {
+    done();
+  });
+
+  it('foo', done => {
+    done();
+  });
+
+});


### PR DESCRIPTION
## Motivation
- Be able to run E2E tests. Since most of the code is JS calling shell commands, each E2E test may need a fresh Ubuntu VM. The flow is as follows: fresh VM -> start app -> run test -> verify the affect on the VM

## Result
- Each of Travis jobs is run in a different environment. So made use of the behavior to make Travis spin up multiple Ubuntu Trusty VMs (effectively Google Compute Engine instances - https://docs.travis-ci.com/user/reference/trusty/#Fully-virtualized-via-sudo%3A-required), each will run an E2E test
- Also include a job for unit tests
- Travis seems to use nvm for `node` language so cannot use node with sudo. Thus, install node manually
- Set language to `bash` to prevent Travis from using Ruby language
- Add some basic tests and extend eslint to be compatible with them
- Use of yaml anchor to avoid DRY (dd_common key)

## Notes
Initially planned to use Travis Stages, but Stages run sequentially, while Jobs run in parallel

## Jira
https://issues.jboss.org/browse/FH-4727
https://issues.jboss.org/browse/FH-4652