### PR TITLE
FH-4729-sonarqube in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,23 @@ dd_common: &common
 jobs:
   include:
     # =======================
+    # Code quality scans (start)
+    # =======================
+    -
+      if: type IN (push)
+      dist: trusty
+      language: bash
+      addons:
+        sonarcloud:
+          organization: "thailekha-github"
+          token:
+            secure: "pcoMbElGfLA7JQfMpLgZKYZS/l77ClMPHcA3+HDjKCgrBCECN3vGdxRG4MHjS24JyEO6DObCt88lVJkozUdFU9k7WZNl30BTX5Xus+1UNZ1C9igRjwVNjmAkG38wDHxqkeBfCbxBykmjnxwhS5Gk1w+e46ZWkH97aIidB8RxqQnTiolUlW3VGatGQdZ4zy8fYZNRsOFpiplO2PMxHoCe+oK0Ejok40Q4vUFQRSi/PTsrFx4lNCP44IuCwVOGJ5GoJOmW1BzMN6yqOUGVEp2PFFDS3lqfehXeqRKwF7qmDHXLlv4qnXIgB76U0OKxmrP/1I83k9Tutx249xiBG5I6njmn4Fy2l/YrrhN3IgShraJcCTdZbMHCAh6q8Qp10Jvk0ohZsclSI84W3zOsandq/lUSd7eEWgF60ieV2jWI+7VENw40S1ktrwAHiZQDQy07r5PMOwuT33hjUi3ZoUw8n29gZEQFJqfF+86YuFUTu5e9eWJSm0JrC08LCUF9MZ0aKruZYkLBiKUR6nb2mxQyO3mkGY5OWheOKejKCXmzxBntI3rry1xg58ldzJltQ1XI+hsTCLcupl2DQ4YjcEQEMvRYcVwl9S/PJ+e2uHGWMW/LOk+6NxFJ71HtPZQ2L29QYaRnNpznpz0ueyvuqhtmWL06pYRxtmB0cIB4vS7bRFo="
+      script:
+      - sonar-scanner --debug
+    # =======================
+    # Code quality scans (end)
+    # =======================
+    # =======================
     # Unit tests (start)
     # =======================
     -

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=dynamic-dockerizer-agent
+sonar.projectName=dynamic-dockerizer-agent
+sonar.projectVersion=0.0.3
+
+sonar.sources=src
+sonar.language=js
+sonar.javascript.lcov.reportPath=./coverage/lcov.info


### PR DESCRIPTION
## Motivation
Run sonarqube scan for code quality

## Result
- Let travis trigger sonarcloud

## Notes
- only master branch is scanned and only when pushing to master branch
- Tried workarounds:
  -  `/.*/` regrex matching any branch
  - `/FH-*/` regrex matching any branch starting with `FH-`
  - `$TRAVIS_BRANCH` env var in `branches` key
  - `$TRAVIS_BRANCH` env var in `sonar-scanner -D` command
  - `unset SONARQUBE_SKIPPED` var
- https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/addons/sonarcloud.rb#L150-L157

## Jira
https://issues.jboss.org/browse/FH-4729